### PR TITLE
Make this script actually fully consider the 

### DIFF
--- a/panel.sh
+++ b/panel.sh
@@ -26,7 +26,7 @@ php artisan config:clear
 echo "Running migrations.."
 php artisan migrate --seed --force
 echo "Setting permissions.."
-chown -R www-data:www-data /var/www/pterodactyl/*
+chown -R www-data:www-data *
 echo "Restarting queue worker.."
 php artisan queue:restart
 echo "Restoring Panel functionality.."


### PR DESCRIPTION
Defining a path to the pterodactyl installation is useless if code further down the script uses the default path. The script is already in the installation directory so no need to define the default path before '*' on the chown command.